### PR TITLE
Feat: 로그인 배너 컴포넌트 구현

### DIFF
--- a/src/components/LoginBanner.tsx
+++ b/src/components/LoginBanner.tsx
@@ -1,0 +1,22 @@
+type LoginBannerProps = {
+  message: string;
+  onClick: () => void;
+};
+
+const LoginBanner = ({ message, onClick }: LoginBannerProps) => {
+  return (
+    <div
+      className={`w-full flex justify-between items-center gap-2 px-2 py-3 rounded text-white bg-primary`}
+    >
+      <span className="text-s font-normal mt-[2px]">{message}</span>
+      <button
+        onClick={onClick}
+        className="text-s border font-normal whitespace-nowrap border-white text-white w-fit px-2 py-1 rounded-lg"
+      >
+        <span className="mt-[2px] inline-block">로그인</span>
+      </button>
+    </div>
+  );
+};
+
+export default LoginBanner;

--- a/src/components/LoginBanner.tsx
+++ b/src/components/LoginBanner.tsx
@@ -1,9 +1,14 @@
 type LoginBannerProps = {
-  message: string;
+  type: 'default' | 'chatbot';
   onClick: () => void;
 };
 
-const LoginBanner = ({ message, onClick }: LoginBannerProps) => {
+const LoginBanner = ({ type, onClick }: LoginBannerProps) => {
+  const message =
+    type === 'chatbot'
+      ? '로그인하고 현재 가입조건을 이용하세요'
+      : '로그인하고 고객님만을 위한 대화를 시작해보세요';
+
   return (
     <div
       className={`w-full flex justify-between items-center gap-2 px-3 py-3 text-white bg-primary`}
@@ -20,3 +25,7 @@ const LoginBanner = ({ message, onClick }: LoginBannerProps) => {
 };
 
 export default LoginBanner;
+
+// 사용 예시
+// <LoginBanner type="default" />
+// <LoginBanner type="chatbot" />

--- a/src/components/LoginBanner.tsx
+++ b/src/components/LoginBanner.tsx
@@ -6,7 +6,7 @@ type LoginBannerProps = {
 const LoginBanner = ({ message, onClick }: LoginBannerProps) => {
   return (
     <div
-      className={`w-full flex justify-between items-center gap-2 px-2 py-3 rounded text-white bg-primary`}
+      className={`w-full flex justify-between items-center gap-2 px-2 py-3 text-white bg-primary`}
     >
       <span className="text-s font-normal mt-[2px]">{message}</span>
       <button

--- a/src/components/LoginBanner.tsx
+++ b/src/components/LoginBanner.tsx
@@ -6,12 +6,12 @@ type LoginBannerProps = {
 const LoginBanner = ({ message, onClick }: LoginBannerProps) => {
   return (
     <div
-      className={`w-full flex justify-between items-center gap-2 px-2 py-3 text-white bg-primary`}
+      className={`w-full flex justify-between items-center gap-2 px-3 py-3 text-white bg-primary`}
     >
-      <span className="text-s font-normal mt-[2px]">{message}</span>
+      <span className="text-sm font-normal mt-[2px]">{message}</span>
       <button
         onClick={onClick}
-        className="text-s border font-normal whitespace-nowrap border-white text-white w-fit px-2 py-1 rounded-lg"
+        className="text-sm border font-normal whitespace-nowrap border-white text-white w-fit px-2 py-1 rounded-lg"
       >
         <span className="mt-[2px] inline-block">로그인</span>
       </button>

--- a/src/router/index.tsx
+++ b/src/router/index.tsx
@@ -7,8 +7,8 @@ import LoginBanner from '../components/Loginbanner';
 // Footer 테스트용 임시 페이지
 const TempPage = () => (
   <div>
-    <LoginBanner message="로그인하고 고객님만을 위한 대화를 시작해보세요" />
-    <LoginBanner message="로그인하고 현재 가입조건을 이용하세요" />
+    <LoginBanner type="default" />
+    <LoginBanner type="chatbot" />
   </div>
 );
 

--- a/src/router/index.tsx
+++ b/src/router/index.tsx
@@ -2,9 +2,15 @@
 import { createHashRouter, RouterProvider } from 'react-router-dom';
 import Default from '../default';
 import TermsOfUsePage from '../pages/TermsOfUsePage';
+import LoginBanner from '../components/Loginbanner';
 
 // Footer 테스트용 임시 페이지
-const TempPage = () => <div>Footer 테스트용 페이지입니다</div>;
+const TempPage = () => (
+  <div>
+    <LoginBanner message="로그인하고 고객님만을 위한 대화를 시작해보세요" />
+    <LoginBanner message="로그인하고 현재 가입조건을 이용하세요" />
+  </div>
+);
 
 const router = createHashRouter([
   {


### PR DESCRIPTION
## 📝 변경 사항(커밋 단위)

1. LoginBanner 컴포넌트를 구현하였습니다.

## 🔍 변경 사항 세부 설명

1-1. 메시지와 로그인 버튼을 포함한 로그인 유도 배너를 구현하였습니다.
1-2. 버튼 클릭 시 onClick 핸들러가 실행되도록 하였습니다. (나중에 버튼 컴포넌트로 바꿀 예정)
1-3. 텍스트가 정가운데에 위치할 수 있도록 mt-[2px] 추가하였습니다.

## 👍사용 예시
```
<LoginBanner type="default" />
<LoginBanner type="chatbot" />
```

## 📷 스크린샷
![image](https://github.com/user-attachments/assets/86656b13-f083-421b-9a32-1642cc50aca5)