### PR TITLE
Feat/버튼 컴포넌트 구현

### DIFF
--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -1,0 +1,81 @@
+import { MdCall } from 'react-icons/md';
+import React from 'react';
+
+type ButtonProps = {
+  variant?: 'fill' | 'outline' | 'ghost' | 'special';
+  color?: 'pink' | 'gray' | 'violet' | 'black';
+  size?: 's' | 'm' | 'lg' | 'xl';
+  onClick?: () => void;
+  children: React.ReactNode;
+  className?: string;
+  disabled?: boolean;
+};
+
+const Button = ({
+  variant = 'fill',
+  color = 'pink',
+  size = 'm',
+  onClick,
+  children,
+  className = '',
+  disabled = false,
+}: ButtonProps) => {
+  // 스타일 정의
+  const variantMap = {
+    fill: {
+      pink: 'bg-pink-500 text-white hover:bg-pink-400 active:bg-pink-600',
+      gray: 'bg-zinc-100 text-zinc-400 hover:bg-zinc-300 active:bg-gray-400',
+      violet: 'bg-violet-100 text-black hover:bg-violet-50',
+    },
+    outline: {
+      pink: 'border border-pink-500 text-pink-500 hover:bg-pink-50 focus:bg-pink-100',
+      gray: 'border border-zinc-200 text-black hover:bg-zinc-100 focus:bg-zinc-200',
+      violet: 'border border-violet-200 text-violet-400 hover:bg-violet-50',
+    },
+    ghost: {
+      pink: 'text-pink-500 hover:bg-pink-50',
+      gray: 'text-zinc-400 hover:bg-gray-100',
+      violet: 'text-violet-700 hover:bg-violet-50',
+      black: 'text-black',
+    },
+  };
+
+  const specialStyle = 'bg-diagonal text-violet-700 shadow-md';
+
+  // 사이즈별 스타일
+  const sizeMap = {
+    s: 'text-xs px-3 h-8 min-w-14',
+    m: 'text-sm px-4 h-9 min-w-20',
+    lg: 'text-m px-5 h-11 min-w-16',
+    xl: 'text-m px-6 h-14 min-w-24',
+  };
+
+  // 둥근 모서리 설정
+  const borderRadius = size === 's' || variant === 'special' ? 'rounded-3xl' : 'rounded-lg';
+
+  // 비활성화 상태 스타일
+  const disabledStyle = 'bg-zinc-200 text-white cursor-not-allowed pointer-events-none';
+
+  // 최종 스타일 조합
+  const variantStyle = variant === 'special' ? specialStyle : variantMap[variant]?.[color] || '';
+
+  const composedClassName = [
+    'inline-flex items-center justify-center font-medium transition',
+    borderRadius,
+    sizeMap[size],
+    variantStyle,
+    disabled ? disabledStyle : '',
+    className,
+  ]
+    .filter(Boolean)
+    .join(' ');
+
+  return (
+    <button onClick={onClick} className={composedClassName} disabled={disabled}>
+      {variant === 'special' && <MdCall className="mr-2 w-5 h-5" />}
+      {children}
+    </button>
+  );
+};
+
+export default Button;

--- a/src/router/index.tsx
+++ b/src/router/index.tsx
@@ -3,9 +3,58 @@ import { createHashRouter, RouterProvider } from 'react-router-dom';
 import Default from '../default';
 import ChatbotMain from '../pages/ChatbotMain';
 import TermsOfUsePage from '../pages/TermsOfUsePage';
+import Button from '../components/Button';
 
 // Footer 테스트용 임시 페이지
-const TempPage = () => <div>Footer 테스트용 페이지입니다</div>;
+const TempPage = () => (
+  <div>
+    <Button variant="outline" color="gray" size="s">
+      outline
+    </Button>
+    <Button variant="outline" color="pink" size="m">
+      outline
+    </Button>
+    <Button variant="outline" color="violet" size="lg">
+      outline
+    </Button>
+    <Button variant="outline" color="pink" size="xl">
+      outline
+    </Button>
+    <br />
+    <br />
+    <Button variant="fill" color="pink" size="s">
+      fill
+    </Button>
+    <Button variant="fill" color="violet" size="m">
+      fill
+    </Button>
+    <Button variant="fill" color="gray" size="lg">
+      fill
+    </Button>
+    <Button variant="fill" color="pink" size="xl">
+      fill
+    </Button>
+    <br />
+    <br />
+    <Button variant="ghost" color="pink" size="s">
+      ghost
+    </Button>
+    <Button variant="ghost" color="gray" size="m">
+      ghost
+    </Button>
+    <Button variant="ghost" color="violet" size="lg">
+      ghost
+    </Button>
+    <Button variant="ghost" color="black" size="xl">
+      ghost
+    </Button>
+    <br />
+    <br />
+    <Button variant="special" size="lg">
+      고객센터 전화걸기
+    </Button>
+  </div>
+);
 
 const router = createHashRouter([
   {


### PR DESCRIPTION
## 📝 변경 사항(커밋 단위)

1. 공통 버튼 컴포넌트를 구현하였습니다.

## 🔍 변경 사항 세부 설명

1-1. variant는 fill | outline | ghost | special 로 나누었습니다.
1-2. color는 pink | gray | violet | black 로 나누었습니다.
1-3. size는 s | m | lg | xl로 나누었습니다.
1-4. min-width를 주어 최소 너비를 설정하였습니다.
1-5. disabled 처리도 가능하도록 하였습니다.
1-6 special variant(고객센터 전화하기 버튼)일 경우 아이콘(MdCall)이 표시되도록 하였습니다.
1-7. ghost variant는 필터 선택 컴포넌트도 버튼 컴포넌트로 처리할 수 있을 거라고 생각해서 넣어봤습니다.

## 👍사용 예시
```
    <Button variant="fill" color="pink" size="s">
      fill
    </Button>
    <Button variant="outline" color="gray" size="m">
      outline
    </Button>
    <Button variant="ghost" color="violet" size="lg">
      ghost
    </Button>
    <Button variant="special" size="lg">
      고객센터 전화걸기
    </Button>
```

## 📷 스크린샷
![image](https://github.com/user-attachments/assets/70cdfad2-7772-46cd-a094-03601ca07e18)
