### PR TITLE
refactor: 모달 타이틀 선택 props로 변경 및 상태 관리 추가

### DIFF
--- a/src/components/Modal.tsx
+++ b/src/components/Modal.tsx
@@ -1,5 +1,5 @@
 import { createPortal } from 'react-dom';
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import { IoCloseOutline } from 'react-icons/io5';
 import Button from './Button';
 
@@ -34,17 +34,30 @@ const Modal = ({
   closeOnOutsideClick = true, // 기본값: 외부 클릭 시 닫힘
 }: ModalProps) => {
   const modalRoot = document.getElementById('modal-root');
+  const [isVisible, setIsVisible] = useState(false);
+
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      setIsVisible(true);
+    }, 8);
+    return () => clearTimeout(timer);
+  }, []);
+
   if (!modalRoot) return null;
 
   const shouldRenderButtons = showButtons && (leftButtonText || rightButtonText);
 
   return createPortal(
     <div
-      className="fixed inset-0 z-50 bg-black/40 flex items-center justify-center"
+      className={`fixed inset-0 z-50 flex items-center justify-center bg-black/40 transition-opacity duration-300 ${
+        isVisible ? 'opacity-100' : 'opacity-0'
+      }`}
       onClick={closeOnOutsideClick ? onClose : undefined} // 외부 클릭 감지
     >
       <div
-        className={`bg-white rounded-2xl drop-shadow-[0_2px_8px_rgba(0,0,0,0.25) ${SIZE_CLASSES[size]}`}
+        className={`bg-white rounded-2xl drop-shadow-[0_2px_8px_rgba(0,0,0,0.25)] transition-all duration-300 ease-out transform ${
+          isVisible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-5'
+        } ${SIZE_CLASSES[size]}`}
         onClick={(e) => e.stopPropagation()} // 내부 클릭은 닫기 방지
       >
         {/* X 버튼: s 사이즈는 제외 */}

--- a/src/components/Modal.tsx
+++ b/src/components/Modal.tsx
@@ -5,7 +5,7 @@ import Button from './Button';
 
 type ModalProps = {
   size?: 's' | 'm';
-  title: string;
+  title?: string;
   subtitle?: string;
   children?: React.ReactNode;
   onClose?: () => void;

--- a/src/hooks/reduxHooks.ts
+++ b/src/hooks/reduxHooks.ts
@@ -1,0 +1,5 @@
+import { TypedUseSelectorHook, useDispatch, useSelector } from 'react-redux';
+import type { RootState, AppDispatch } from '../store/store';
+
+export const useAppDispatch: () => AppDispatch = useDispatch;
+export const useAppSelector: TypedUseSelectorHook<RootState> = useSelector;

--- a/src/hooks/reduxHooks.ts
+++ b/src/hooks/reduxHooks.ts
@@ -1,5 +1,5 @@
 import { TypedUseSelectorHook, useDispatch, useSelector } from 'react-redux';
 import type { RootState, AppDispatch } from '../store/store';
 
-export const useAppDispatch: () => AppDispatch = useDispatch;
-export const useAppSelector: TypedUseSelectorHook<RootState> = useSelector;
+export const useAppDispatch = useDispatch.withTypes<AppDispatch>();
+export const useAppSelector = useSelector.withTypes<RootState>();

--- a/src/hooks/reduxHooks.ts
+++ b/src/hooks/reduxHooks.ts
@@ -1,4 +1,4 @@
-import { TypedUseSelectorHook, useDispatch, useSelector } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
 import type { RootState, AppDispatch } from '../store/store';
 
 export const useAppDispatch = useDispatch.withTypes<AppDispatch>();

--- a/src/router/index.tsx
+++ b/src/router/index.tsx
@@ -9,6 +9,11 @@ import Modal from '../components/Modal';
 import { HeaderProps } from '../components/Header';
 import { useEffect } from 'react';
 
+import { useDispatch, useSelector } from 'react-redux';
+import { RootState } from '../store/store'; // store.ts 위치에 맞게 경로 조정
+import { openModal, closeModal } from '../store/modalSlice';
+import Button from '../components/Button';
+
 // 테스트용 임시 페이지
 const TempPage = () => {
   const setHeaderConfig = useOutletContext<(config: HeaderProps) => void>();
@@ -20,24 +25,43 @@ const TempPage = () => {
     });
   }, []);
 
+  // 모달 테스트
+  const dispatch = useDispatch();
+
+  const handleOpen = () => {
+    dispatch(openModal());
+  };
+
+  const handleClose = () => {
+    dispatch(closeModal());
+  };
+
+  const isOpen = useSelector((state: RootState) => state.modal.isOpen);
+
   return (
     <div className="py-10">
       <BenefitDropBar label="할인 혜택" indexes={[0, 1, 2, 3, 4]} data={benefitList} />
       <BenefitDropBar label="기본 혜택" indexes={[5, 6, 7, 8, 9]} data={benefitList} />
-      <Modal
-        title="내가 작성한 리뷰"
-        subtitle="삭제한 리뷰는 다시 되돌릴 수 없어요. 🥲"
-        size="s"
-        showButtons
-        leftButtonText="취소"
-        rightButtonText="삭제하기"
-        onClose={() => console.log('닫기')} // 모달 닫기 테스트
-        onConfirm={() => console.log('삭제')} // 버튼 확인 테스트용
-      >
-        {/* <p>
+      <Button onClick={() => dispatch(openModal())}>모달</Button>
+      {isOpen && (
+        <Modal
+          title="내가 작성한 리뷰"
+          subtitle="삭제한 리뷰는 다시 되돌릴 수 없어요. 🥲"
+          size="s"
+          showButtons
+          leftButtonText="취소"
+          rightButtonText="삭제하기"
+          onClose={handleClose} // 모달 닫기 테스트
+          onConfirm={() => {
+            console.log('삭제');
+            dispatch(closeModal());
+          }} // 버튼 확인 테스트용
+        >
+          {/* <p>
           안뇽안뇽안뇽안뇽안뇽안뇽안뇽안뇽안뇽안뇽안뇽안뇽안뇽안뇽안뇽안뇽안뇽안뇽안뇽안뇽안뇽안뇽안뇽안뇽안뇽안뇽안뇽안뇽안뇽안뇽안뇽안뇽안뇽안뇽안뇽안뇽안뇽안뇽안뇽안뇽안뇽안뇽안뇽안뇽안뇽안뇽안뇽안뇽안뇽안뇽안뇽안뇽안뇽안뇽안뇽안뇽안뇽안뇽안뇽안뇽안뇽안뇽안뇽안뇽안뇽안뇽안뇽안뇽안뇽안뇽안뇽안뇽안뇽안뇽안뇽안뇽안뇽안뇽안뇽안뇽안뇽안뇽안뇽안뇽안뇽안뇽안뇽안뇽안뇽안뇽안뇽안뇽안뇽안뇽안뇽안뇽안뇽안뇽안뇽안뇽안뇽안뇽안뇽안뇽안뇽안뇽안뇽안뇽
         </p> */}
-      </Modal>
+        </Modal>
+      )}
     </div>
   );
 };

--- a/src/router/index.tsx
+++ b/src/router/index.tsx
@@ -9,7 +9,7 @@ import Modal from '../components/Modal';
 import { HeaderProps } from '../components/Header';
 import { useEffect } from 'react';
 
-import { useDispatch, useSelector } from 'react-redux';
+import { useAppDispatch, useAppSelector } from '../hooks/reduxHooks';
 import { RootState } from '../store/store'; // store.ts 위치에 맞게 경로 조정
 import { openModal, closeModal } from '../store/modalSlice';
 import Button from '../components/Button';
@@ -26,7 +26,7 @@ const TempPage = () => {
   }, []);
 
   // 모달 테스트
-  const dispatch = useDispatch();
+  const dispatch = useAppDispatch();
 
   const handleOpen = () => {
     dispatch(openModal());
@@ -36,7 +36,7 @@ const TempPage = () => {
     dispatch(closeModal());
   };
 
-  const isOpen = useSelector((state: RootState) => state.modal.isOpen);
+  const isOpen = useAppSelector((state) => state.modal.isOpen);
 
   return (
     <div className="py-10">

--- a/src/store/modalSlice.ts
+++ b/src/store/modalSlice.ts
@@ -1,0 +1,25 @@
+import { createSlice } from '@reduxjs/toolkit';
+
+interface ModalState {
+  isOpen: boolean;
+}
+
+const initialState: ModalState = {
+  isOpen: false,
+};
+
+const modalSlice = createSlice({
+  name: 'modal',
+  initialState,
+  reducers: {
+    openModal: (state) => {
+      state.isOpen = true;
+    },
+    closeModal: (state) => {
+      state.isOpen = false;
+    },
+  },
+});
+
+export const { openModal, closeModal } = modalSlice.actions;
+export default modalSlice.reducer;

--- a/src/store/store.ts
+++ b/src/store/store.ts
@@ -1,5 +1,11 @@
 import { configureStore } from '@reduxjs/toolkit';
+import modalReducer from './modalSlice';
 
 export const store = configureStore({
-  reducer: {},
+  reducer: {
+    modal: modalReducer,
+  },
 });
+
+export type RootState = ReturnType<typeof store.getState>;
+export type AppDispatch = typeof store.dispatch;


### PR DESCRIPTION
## 📝 변경 사항

1. 모달에 타이틀이 필요없는 경우를 대비해 타이틀 속성을 선택으로 바꿨습니다.
2. 모달 상태 관리를 위해 Redux slice 및 store를 추가하였습니다.

## ✨ 상세 설명
2-1. modalSlice를 생성하여 isOpen 상태를 관리하는 초기 상태(false)를 정의하였고, openModal 및 closeModal reducer 함수를 추가하여 모달 열기/닫기 동작을 정의하였습니다.
2-2. modalReducer를 store에 등록하여 전역 상태로 관리 가능하도록 구성하였습니다.
2-3. RootState 및 AppDispatch 타입 정의로 타입 안정성을 확보하였습니다.

## 👍 사용 예시
```
// useDispatch 대신 useAppDispatch 사용하기
const dispatch = useAppDispatch();

const handleOpen = () => {
  dispatch(openModal());
};

const handleClose = () => {
  dispatch(closeModal());
};

const isOpen = useAppSelector((state) => state.modal.isOpen);

<Button onClick={() => dispatch(openModal())}>모달</Button>
{isOpen && (<Modal ...></Modal>)}

// 사용하지 않을 경우 매번 타입을 붙여야함
const isOpen = useSelector((state: RootState) => state.modal.isOpen);
```
