### PR TITLE
refactor: 토스트 중복된 스타일 분리 및 반응형 처리

### DIFF
--- a/src/context/ToastContext.tsx
+++ b/src/context/ToastContext.tsx
@@ -34,7 +34,7 @@ export const ToastProvider = ({ children }: { children: ReactNode }) => {
       {children}
       <ToastContainer
         position="bottom-center"
-        // autoClose={2000}
+        autoClose={2000}
         limit={1}
         hideProgressBar={true}
         closeOnClick

--- a/src/context/ToastContext.tsx
+++ b/src/context/ToastContext.tsx
@@ -1,60 +1,32 @@
 // src/context/ToastContext.tsx
-import React, { createContext, ReactNode } from 'react';
-import { Bounce, toast, ToastContainer } from 'react-toastify';
+import { createContext, ReactNode } from 'react';
+import { Slide, toast, ToastContainer } from 'react-toastify';
 import 'react-toastify/dist/ReactToastify.css';
-import { FaCheck } from 'react-icons/fa';
-import { MdErrorOutline } from 'react-icons/md';
-// toast 타입 정의에 "custom" 추가
-type ToastType = 'default' | 'success' | 'error' | 'info' | 'custom';
+
+type ToastType = 'success' | 'error' | 'violet' | 'black';
 
 interface ToastContextType {
   showToast: (msg: string, type?: ToastType) => void;
 }
 
-// context 객체 생성
 export const ToastContext = createContext<ToastContextType | null>(null);
 
 export const ToastProvider = ({ children }: { children: ReactNode }) => {
-  const showToast = (msg: string, type: ToastType = 'default') => {
-    switch (type) {
-      case 'success':
-        toast.success(msg, {
-          icon: (
-            <div className="ml-2 bg-white text-blue-500 rounded-full w-5 h-5 flex items-center justify-center ">
-              <FaCheck className="w-5 h-3" />
-            </div>
-          ),
-          className:
-            'bg-blue-500 text-white text-s  rounded  max-w-[60%] mx-auto itmes-center shadow flex gap-2  gap-4 ',
-        });
-        break;
-      case 'error':
-        toast.error(msg, {
-          icon: (
-            <div className="ml-2 bg-white text-red-500 rounded-full w-5 h-5 flex items-center justify-center">
-              <MdErrorOutline className="w-6 h-6" />
-            </div>
-          ),
-          className:
-            'bg-red-500 text-white text-s  rounded  max-w-[60%] mx-auto shadow flex items-center  gap-2  ',
-        });
-        break;
-      case 'info':
-        toast.info(msg, {
-          className:
-            'bg-green-500 text-white  text-s  rounded max-h-[10px] max-w-[60%] mx-auto shadow  flex items-center justify-center  ',
-        });
-        break;
-      case 'custom':
-        toast(msg, {
-          className:
-            'bg-violet-900 text-white text-s  rounded max-h-[10px] max-w-[60%] mx-auto shadow text-center flex items-center justify-center ',
-        });
-        break;
-      default:
-        toast(msg);
-        break;
-    }
+  const baseStyle =
+    'sm:w-[500px] max-[480px]:w-[90%] mx-auto text-white text-sm sm:text-m rounded-2xl items-center drop-shadow-lg flex justify-center';
+
+  const toastStyles: Record<ToastType, string> = {
+    success: `bg-blue-500 ${baseStyle}`,
+    error: `bg-red-500 ${baseStyle}`,
+    violet: `bg-violet-900 ${baseStyle}`,
+    black: `bg-black/50 backdrop-blur-md ${baseStyle}`,
+  };
+
+  const showToast = (msg: string, type: ToastType = 'error') => {
+    toast(msg, {
+      className: toastStyles[type],
+      icon: false,
+    });
   };
 
   return (
@@ -62,14 +34,15 @@ export const ToastProvider = ({ children }: { children: ReactNode }) => {
       {children}
       <ToastContainer
         position="bottom-center"
-        autoClose={2500}
+        // autoClose={2000}
+        limit={1}
         hideProgressBar={true}
         closeOnClick
-        closeButton={false}
-        theme={undefined}
+        draggable
         pauseOnHover
-        draggable={false}
-        newestOnTop={true}
+        closeButton={false}
+        transition={Slide}
+        icon={false}
       />
     </ToastContext.Provider>
   );

--- a/src/index.css
+++ b/src/index.css
@@ -44,14 +44,6 @@ body {
   font-size: inherit; /* 16px */
 }
 
-/*toastify 기본속성이 적용되어 tailwind로 안되서 전역으로 important해서 적용 */
-.Toastify__toast {
-  min-height: unset !important; /* unset : 해당 속성이 상속 가능한 속성일 때는 inherit 상속되지 않는 속성일 때는 initial  */
-  padding: 8px 4px !important;
-  margin: 4px 0 !important;
-  border-radius: 6px !important;
-}
-
 /*스크롤바 안보이게 */
 .scrollbar-hidden {
   scrollbar-width: none;

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -4,11 +4,14 @@ import { Provider } from 'react-redux';
 import Router from './router';
 import './index.css';
 import { store } from './store/store';
+import { ToastProvider } from './context/ToastContext';
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
     <Provider store={store}>
-      <Router />
+      <ToastProvider>
+        <Router />
+      </ToastProvider>
     </Provider>
   </StrictMode>
 );

--- a/src/router/index.tsx
+++ b/src/router/index.tsx
@@ -10,7 +10,10 @@ import LoginPage from '../pages/LoginPage';
 import LoginBanner from '../components/LoginBanner';
 import Modal from '../components/Modal';
 import { HeaderProps } from '../components/Header';
-import { useEffect } from 'react';
+import { useContext, useEffect } from 'react';
+import Button from '../components/Button';
+
+import { ToastContext } from '../context/ToastContext';
 
 // 테스트용 임시 페이지
 const TempPage = () => {
@@ -23,10 +26,23 @@ const TempPage = () => {
     });
   }, []);
 
+  const toastContext = useContext(ToastContext);
+
+  const handleClick = () => {
+    toastContext?.showToast('리뷰가 삭제되었습니다!', 'black');
+  };
+
   return (
     <div className="py-10">
       <BenefitDropBar label="할인 혜택" indexes={[0, 1, 2, 3, 4]} data={benefitList} />
       <BenefitDropBar label="기본 혜택" indexes={[5, 6, 7, 8, 9]} data={benefitList} />
+      <Button onClick={handleClick}>토스트 리뷰 삭제</Button>
+      <Button onClick={() => toastContext?.showToast('비밀번호가 변경되었습니다!', 'success')}>
+        토스트 성공
+      </Button>
+      <Button onClick={() => toastContext?.showToast('비밀번호가 일치하지 않습니다')}>
+        토스트 실패
+      </Button>
     </div>
   );
 };


### PR DESCRIPTION
## 📝 변경 사항

1. 토스트 컴포넌트를 리팩토링하였습니다.

## 🔍 변경 사항 세부 설명
1-1. 공통 baseStyle을 추출하여 토스트 타입별 중복되는 스타일을 제거하여 유지보수가 용이하도록 하였습니다.
1-2. sm 이상에서 w-[500px], 480px 이하에서는 w-[90%] 적용되도록 반응형 처리를 하였습니다.
1-3. icon를 제거하여 토스트 스타일을 통일시켰습니다. (색깔만 다름)
1-4. 모바일에서 자주 사용하는 뒷배경이 블러 처리된 투명도 50% 정도의 black 타입을 추가하였습니다. (만약을 대비)
1-5. 적용되지 않는 스타일을 정리하였습니다.
1-6. 애니메이션을 Bounce -> Slide로 밑에서 스르륵 올라오도록 하였습니다.
1-7. 옆으로 슬라이드하면 사라지도록 하였습니다.
1-8. 타입은 success, error, violet, black으로 나누고, 기본은 error로 설정해놓았습니다.

## 📷 스크린샷
![Animation2](https://github.com/user-attachments/assets/8f9cf741-b03d-4c1e-a97f-2891e1578b00)
![Animation3](https://github.com/user-attachments/assets/501440f5-319d-4a04-af6f-fb96e22beb98)

## 🕵️‍♀️ 요청사항
1. 먼저 민석님,, 죄송합니다 열심히 해주셨는데 디자인을 쪼금 통일성 있게 변경해서 코드가 좀 바꼈습니다...
5. max-width 사이즈를 500px로 두었는데, 나중에 모달 사이즈에 맞춰서 바꿔야 할 듯 합니다 !
