### PR TITLE
fix: focusTrap과 모달 밖 클릭 시 닫히는 기능 충돌로 인한 모달 밖 클릭 시 닫기 기능 제거

### DIFF
--- a/src/components/Modal/BaseModal.tsx
+++ b/src/components/Modal/BaseModal.tsx
@@ -5,18 +5,11 @@ import { FocusTrap } from 'focus-trap-react';
 type BaseModalProps = {
   children: React.ReactNode;
   onClose: () => void;
-  closeOnOutsideClick?: boolean;
   className?: string;
   labelledBy?: string;
 };
 
-const BaseModal = ({
-  children,
-  onClose,
-  closeOnOutsideClick = true,
-  className = '',
-  labelledBy,
-}: BaseModalProps) => {
+const BaseModal = ({ children, onClose, className = '', labelledBy }: BaseModalProps) => {
   const modalRoot = document.getElementById('modal-root');
   const [isVisible, setIsVisible] = useState(false);
 
@@ -53,7 +46,6 @@ const BaseModal = ({
       className={`fixed inset-0 z-50 bg-black/40 flex items-center justify-center transition-opacity duration-300 ${
         isVisible ? 'opacity-100' : 'opacity-0'
       }`}
-      onClick={closeOnOutsideClick ? onClose : undefined}
     >
       <FocusTrap>
         <div


### PR DESCRIPTION
## 📝 변경 사항

1. tab키로 모달 내부에서만 이동할 수 있는 기능과 모달 밖 클릭 시 닫히는 기능 충돌로 인해 모달 밖 클릭 시 닫히는 기능을 제거하였습니다.
