### PR TITLE
Fix/헤더 고정 및 모바일 환경 비로그인 마이페지 접근 시 로그인으로

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -99,7 +99,7 @@ const Header = ({
 
   return (
     <header
-      className={`relative z-50 w-full h-16 flex justify-center items-center px-[5%] py-6 bg-white 
+      className={`fixed z-50 w-full h-16 flex justify-center items-center px-[5%] py-6 bg-white 
         ${hasShadow ? 'shadow-header' : 'shadow-none'} md:shadow-none md:px-10`}
     >
       <div className="relative w-full h-full flex items-center justify-between">
@@ -194,9 +194,17 @@ const Header = ({
               안녕하세요
             </span>
             <div className="flex items-center mb-[-20px] ml-4">
-              <Link to="/mypage">
+              <button
+                onClick={() => {
+                  if (user?.name) {
+                    navigate('/mypage');
+                  } else {
+                    navigate('/login');
+                  }
+                }}
+              >
                 <p className="text-sm">마이페이지 및 설정</p>
-              </Link>
+              </button>
               <SlArrowRight className="w-[10px] h-[10px] ml-[2px]" />
             </div>
           </div>


### PR DESCRIPTION
## 📝 변경 사항(커밋 단위)

1. 헤더 고정 및 모바일 환경 비로그인 마이페이지 접근 시 로그인으로

## 🔍 변경 사항 세부 설명

1-1. 헤더 fixed로 바꿧습니다
1-2. 비 로그인 시 모바일 환경에서 마이페이지 접근경로 모두 막아놓음

## 📷 스크린샷 (선택)
![chat5](https://github.com/user-attachments/assets/c14027ec-59e0-4306-93b2-5fe9411175dc)
## 🕵️‍♀️ 요청사항 (선택)
